### PR TITLE
Add support for 'su' directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,6 @@ Supported vars:
    - max_size (default: '10M') - max log size before being rotated
    - max_count (default: 5) - nr of old log files kept
    - email (optional) - the email address which is mailed the log files being rotated out of existence
+   - su_user (optional) - Required when rotating logs not owned by root,
+                          or located in a world-writable directory.
+   - su_group (required if `su_user`) - same as above.

--- a/templates/program.conf.j2
+++ b/templates/program.conf.j2
@@ -2,7 +2,11 @@
     missingok
     notifempty
     sharedscripts
-    
+
+{% if item.su_user is defined and item.su_group is defined %}
+    su {{ item.su_user }} {{ item.su_group }}
+{% endif %}
+
     compress
     delaycompress
 


### PR DESCRIPTION
When rotating logs that live in a world, or non-root writable directory,
the ``su`` directive is required.  Add optional variables for
``su_user`` and ``su_group`` to the template.  Update README.

Signed-off-by: Chris Evich <cevich@redhat.com>